### PR TITLE
Add cookie-based authentication to reduce basic auth overhead

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,18 +1,46 @@
 class ApplicationController < ActionController::Base
   include ActiveStorage::SetCurrent
 
+  AUTH_COOKIE_NAME = :kiosk_auth
+  AUTH_COOKIE_VALUE = "kiosk".freeze
+  AUTH_COOKIE_DURATION = 1.year
+
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
   before_action :basic_auth
 
   def basic_auth
-    return if authenticate_with_http_basic { |user, password| valid_authentication?(user, password) }
+    return if authenticated_via_cookie?
+    return if authenticate_with_http_basic { |user, password| handle_basic_auth(user, password) }
 
     request_http_basic_authentication
   end
 
-   def valid_authentication?(username, password)
+  private
+
+  def authenticated_via_cookie?
+    cookies.signed[AUTH_COOKIE_NAME] == AUTH_COOKIE_VALUE
+  end
+
+  def handle_basic_auth(username, password)
+    return false unless valid_authentication?(username, password)
+
+    persist_auth_cookie
+    true
+  end
+
+  def valid_authentication?(username, password)
     username == "kiosk" && password == "sup3r-s3cr37"
+  end
+
+  def persist_auth_cookie
+    cookies.signed[AUTH_COOKIE_NAME] = {
+      value: AUTH_COOKIE_VALUE,
+      expires: AUTH_COOKIE_DURATION.from_now,
+      httponly: true,
+      same_site: :lax,
+      secure: Rails.env.production?
+    }
   end
 end

--- a/test/controllers/application_controller_auth_test.rb
+++ b/test/controllers/application_controller_auth_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class ApplicationControllerAuthTest < ActionDispatch::IntegrationTest
+  BASIC_AUTH_HEADER = {
+    "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials("kiosk", "sup3r-s3cr37")
+  }.freeze
+
+  test "request without credentials is challenged" do
+    get root_path
+    assert_response :unauthorized
+  end
+
+  test "valid basic auth sets a signed kiosk_auth cookie" do
+    get root_path, headers: BASIC_AUTH_HEADER
+    assert_response :success
+
+    signed_value = cookies.signed[ApplicationController::AUTH_COOKIE_NAME]
+    assert_equal ApplicationController::AUTH_COOKIE_VALUE, signed_value
+  end
+
+  test "subsequent request with only the cookie bypasses basic auth" do
+    get root_path, headers: BASIC_AUTH_HEADER
+    assert_response :success
+
+    get root_path
+    assert_response :success
+  end
+
+  test "tampered cookie value is rejected" do
+    cookies[ApplicationController::AUTH_COOKIE_NAME] = "kiosk"
+
+    get root_path
+    assert_response :unauthorized
+  end
+end


### PR DESCRIPTION
## Summary
Implemented a cookie-based authentication system that allows users to authenticate once via HTTP Basic Auth and then use a signed cookie for subsequent requests, reducing the need to send credentials with every request.

## Key Changes
- Added signed cookie authentication as the primary auth check, falling back to HTTP Basic Auth if no valid cookie exists
- Introduced three authentication constants: `AUTH_COOKIE_NAME`, `AUTH_COOKIE_VALUE`, and `AUTH_COOKIE_DURATION` (1 year)
- Created `authenticated_via_cookie?` method to validate signed cookie presence and integrity
- Refactored `handle_basic_auth` to set a signed cookie upon successful credential validation
- Added `persist_auth_cookie` method that sets a secure, httponly, same-site cookie with appropriate expiration
- Added comprehensive integration tests covering: unauthenticated requests, valid basic auth with cookie creation, cookie-based bypass of basic auth, and tampered cookie rejection

## Implementation Details
- Cookies are signed using Rails' built-in cookie signing to prevent tampering
- Cookie security is configured with `httponly: true` and `same_site: :lax` to mitigate XSS and CSRF attacks
- The `secure` flag is only set in production environments to allow local development
- Authentication check order prioritizes cookies first for performance, then falls back to basic auth

https://claude.ai/code/session_01Go7STshkf1G5pDfNASPp35