### PR TITLE
Upgrade Ruby version from 3.4.7 to 3.4.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # For a containerized dev environment, see Dev Containers: https://guides.rubyonrails.org/getting_started_with_devcontainer.html
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
-ARG RUBY_VERSION=3.4.7
+ARG RUBY_VERSION=3.4.8
 FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 
 # Rails app lives here


### PR DESCRIPTION
## Summary
Updates the Ruby version used in the Docker container from 3.4.7 to 3.4.8.

## Changes
- Updated `RUBY_VERSION` ARG in Dockerfile from 3.4.7 to 3.4.8

## Details
This patch version upgrade includes bug fixes and improvements from the Ruby 3.4.8 release. The change ensures the containerized environment uses the latest patch version of Ruby 3.4.

https://claude.ai/code/session_01SVG1fD5PEu96ZucCV5Yw7a