### PR TITLE
Fix signed cookie access in authentication controller test

### DIFF
--- a/test/controllers/application_controller_auth_test.rb
+++ b/test/controllers/application_controller_auth_test.rb
@@ -14,7 +14,8 @@ class ApplicationControllerAuthTest < ActionDispatch::IntegrationTest
     get root_path, headers: BASIC_AUTH_HEADER
     assert_response :success
 
-    signed_value = cookies.signed[ApplicationController::AUTH_COOKIE_NAME]
+    jar = ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash)
+    signed_value = jar.signed[ApplicationController::AUTH_COOKIE_NAME]
     assert_equal ApplicationController::AUTH_COOKIE_VALUE, signed_value
   end
 


### PR DESCRIPTION
## Summary
Updated the authentication controller test to properly access signed cookies by explicitly building a CookieJar instance with the request context.

## Key Changes
- Modified the signed cookie retrieval logic in `ApplicationControllerAuthTest` to use `ActionDispatch::Cookies::CookieJar.build()` instead of directly accessing `cookies.signed`
- This ensures the cookie jar has the proper request context needed to correctly decrypt and access signed cookie values

## Implementation Details
The change addresses an issue where accessing signed cookies directly from the `cookies` helper in integration tests may not have the necessary request context. By explicitly building a `CookieJar` instance with both the request and cookies hash, the signed cookie decryption works correctly during test execution.

https://claude.ai/code/session_0177mH6pk6hqSiyDg1UWAKfw