### PR TITLE
Render EPC payment QR as PNG image

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -194,7 +194,8 @@ header nav ol {
   display: block;
 }
 
-.roundup__qr-variant svg {
+.roundup__qr-variant img,
+.roundup__qr-variant .epc-qr {
   width: 100%;
   height: 100%;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,15 +82,15 @@ module ApplicationHelper
     ].join("\n")
   end
 
-  def epc_qr_svg(amount_in_cents, remittance)
+  def epc_qr_image(amount_in_cents, remittance)
     payload = epc_qr_payload(amount_in_cents, remittance)
-    RQRCode::QRCode.new(payload, level: :m).as_svg(
-      module_size: 4,
-      standalone: true,
-      use_path: true,
-      viewbox: true,
-      svg_attributes: { class: "epc-qr" }
-    ).html_safe
+    png = RQRCode::QRCode.new(payload, level: :m).as_png(
+      border_modules: 4,     # quiet zone — required for scanners
+      module_px_size: 8,     # crisp resolution
+      color: "black",
+      fill: "white"          # opaque white bg keeps contrast in dark mode
+    )
+    image_tag(png.to_data_url, alt: "EPC-QR-Code", class: "epc-qr")
   end
 
   def rounded_up_full_euro_in_cents(amount_in_cents)

--- a/app/views/external/client/show.html.slim
+++ b/app/views/external/client/show.html.slim
@@ -40,13 +40,13 @@ p
         span= Rails.configuration.kiosk_iban
       .roundup__qr
         .roundup__qr-variant.roundup__qr-variant--active data-variant="exact"
-          == epc_qr_svg(outstanding_in_cents, epc_remittance(@client.name, outstanding_in_cents, outstanding_in_cents))
+          = epc_qr_image(outstanding_in_cents, epc_remittance(@client.name, outstanding_in_cents, outstanding_in_cents))
         .roundup__qr-variant data-variant="rounded"
-          == epc_qr_svg(rounded_up_in_cents, epc_remittance(@client.name, outstanding_in_cents, rounded_up_in_cents))
+          = epc_qr_image(rounded_up_in_cents, epc_remittance(@client.name, outstanding_in_cents, rounded_up_in_cents))
         .roundup__qr-variant data-variant="exactGenerous"
-          == epc_qr_svg(exact_generous_in_cents, epc_remittance(@client.name, outstanding_in_cents, exact_generous_in_cents))
+          = epc_qr_image(exact_generous_in_cents, epc_remittance(@client.name, outstanding_in_cents, exact_generous_in_cents))
         .roundup__qr-variant data-variant="roundedGenerous"
-          == epc_qr_svg(rounded_generous_in_cents, epc_remittance(@client.name, outstanding_in_cents, rounded_generous_in_cents))
+          = epc_qr_image(rounded_generous_in_cents, epc_remittance(@client.name, outstanding_in_cents, rounded_generous_in_cents))
       p.roundup__hint Du kannst die Rechnung gerne exakt begleichen oder aufrunden.
       label.roundup__toggle
         input.roundup__checkbox type="checkbox"


### PR DESCRIPTION
## Summary
- Replace inline-SVG QR rendering (`epc_qr_svg`) with a PNG `<img>` (`epc_qr_image`) via `RQRCode#as_png` + base64 data URL, so users viewing the page on their own phone can long-press the code to save/share it into a banking app
- PNG bakes in an opaque white background and a 4-module quiet zone — fixes poor dark-mode contrast and improves scanner reliability
- Update the `external/client/show` view calls and `.roundup__qr-variant` CSS to target the `<img>` element